### PR TITLE
Use LastIndex to split ident name

### DIFF
--- a/template.go
+++ b/template.go
@@ -109,14 +109,13 @@ func (td *TempalteData) name(v reflect.Value) string {
 }
 
 func (td *TempalteData) objectOf(s string) Object {
-	ss := strings.Split(s, ".")
+	dotPos := strings.LastIndex(s, ".")
 
-	switch len(ss) {
-	case 1:
+	if dotPos == -1 {
 		obj := types.Universe.Lookup(s)
 		return NewObject(obj)
-	case 2:
-		pkg, name := ss[0], ss[1]
+	} else {
+		pkg, name := s[:dotPos], s[dotPos+1:]
 		obj := analysisutil.LookupFromImports(td.Pkg.Imports(), pkg, name)
 		if obj != nil {
 			return NewObject(obj)
@@ -126,7 +125,6 @@ func (td *TempalteData) objectOf(s string) Object {
 		}
 		return NewObject(td.Pkg.Scope().Lookup(name))
 	}
-	return nil
 }
 
 func (td *TempalteData) typeOf(s string) *Type {


### PR DESCRIPTION
When trying to resolve object with packageName like `github.com`, the previous code will split the name into several pieces which is not correct.

In this PR, I first get the position of dot searching from RHS of a string, then split it into two parts. It works well for both object from stdlib and from 3rd-parties libraries.