### PR TITLE
Make Type.Named return expected Named value instead of nil

### DIFF
--- a/types.go
+++ b/types.go
@@ -80,7 +80,7 @@ func (t *Type) Signature() *Signature {
 }
 
 func (t *Type) Named() *Named {
-	n, _ := under(t.TypesType).(*types.Named)
+	n, _ := t.TypesType.(*types.Named)
 	return NewNamed(n)
 }
 


### PR DESCRIPTION
[As the document says](https://github.com/golang/go/blob/3d80761531a6eb02934bc6b7236d77723f0b54fe/src/go/types/type.go#L11), types returned from types.Type.Underlying are never `Named`. So, current Type.Named func seems to always return a `nil`.
Given that, this PR makes Type.Named do not use `under` to make it correctly return a Named type.