### PR TITLE
Add -tests flag to control test file inclusion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Instructions for knife project
+
+- Use Go for investigations with cutter
+- Practice dogfooding - use knife/cutter tools to analyze the knife codebase itself
+- If the MCP cutter usability is poor or encounters issues, create GitHub issues to improve the user experience
+- Do not give up and immediately resort to grep or rg - persist with cutter/knife tools
+- If MCP error messages are unclear or hard to understand, improve them as well

--- a/cmd/cutter/main.go
+++ b/cmd/cutter/main.go
@@ -23,6 +23,7 @@ var (
 	flagFormat    string
 	flagTemplate  string
 	flagExtraData string
+	flagTests     bool
 )
 
 func init() {
@@ -30,6 +31,7 @@ func init() {
 	flag.StringVar(&flagFormat, "f", "{{.}}", "output format")
 	flag.StringVar(&flagTemplate, "template", "", "template file")
 	flag.StringVar(&flagExtraData, "data", "", "extra data (key:value,key:value)")
+	flag.BoolVar(&flagTests, "tests", true, "include test files")
 	flag.Parse()
 }
 
@@ -51,7 +53,10 @@ func run(ctx context.Context, args []string) error {
 		return runMCPServer(ctx)
 	}
 
-	c, err := cutter.New(args...)
+	cutterOpt := &cutter.CutterOption{
+		Tests: flagTests,
+	}
+	c, err := cutter.New(cutterOpt, args...)
 	if err != nil {
 		return err
 	}

--- a/cmd/hagane/main.go
+++ b/cmd/hagane/main.go
@@ -36,12 +36,13 @@ func main() {
 }
 
 func run() (rerr error) {
-	k, err := knife.New(flag.Args()[1:]...)
+	knifeOpt := &knife.KnifeOption{Tests: true}
+	k, err := knife.New(knifeOpt, flag.Args()[1:]...)
 	if err != nil {
 		return fmt.Errorf("cannot create knife: %w", err)
 	}
 
-	var opt knife.Option
+	var opt knife.ExecuteOption
 	if flagExtraData != "" {
 		err := json.Unmarshal([]byte(flagExtraData), &opt.ExtraData)
 		if err != nil {

--- a/cmd/knife/main.go
+++ b/cmd/knife/main.go
@@ -20,6 +20,7 @@ var (
 	flagTemplate  string
 	flagExtraData string
 	flagXPath     string
+	flagTests     bool
 )
 
 func init() {
@@ -28,6 +29,7 @@ func init() {
 	flag.StringVar(&flagTemplate, "template", "", "template file")
 	flag.StringVar(&flagExtraData, "data", "", "extra data (key:value,key:value)")
 	flag.StringVar(&flagXPath, "xpath", "", "A XPath expression for an AST node")
+	flag.BoolVar(&flagTests, "tests", true, "include test files")
 	flag.Parse()
 }
 
@@ -49,14 +51,17 @@ func run(ctx context.Context, args []string) error {
 		return runMCPServer(ctx)
 	}
 
-	k, err := knife.New(args...)
+	knifeOpt := &knife.KnifeOption{
+		Tests: flagTests,
+	}
+	k, err := knife.New(knifeOpt, args...)
 	if err != nil {
 		return err
 	}
 
 	var w io.Writer = os.Stdout
 
-	opt := &knife.Option{
+	opt := &knife.ExecuteOption{
 		XPath: flagXPath,
 	}
 

--- a/cmd/objls/main.go
+++ b/cmd/objls/main.go
@@ -36,7 +36,8 @@ func main() {
 }
 
 func run(ctx context.Context, args []string) error {
-	c, err := cutter.New(args...)
+	cutterOpt := &cutter.CutterOption{Tests: true}
+	c, err := cutter.New(cutterOpt, args...)
 	if err != nil {
 		return err
 	}

--- a/cmd/typels/main.go
+++ b/cmd/typels/main.go
@@ -42,7 +42,8 @@ func main() {
 }
 
 func run(ctx context.Context, args []string) error {
-	c, err := cutter.New(args...)
+	cutterOpt := &cutter.CutterOption{Tests: true}
+	c, err := cutter.New(cutterOpt, args...)
 	if err != nil {
 		return err
 	}

--- a/cutter/cutter.go
+++ b/cutter/cutter.go
@@ -13,6 +13,11 @@ import (
 	"github.com/gostaticanalysis/knife"
 )
 
+// CutterOption is an option for New.
+type CutterOption struct {
+	Tests bool
+}
+
 // Cutter is a lightweight version of Knife which is resterected for type information.
 type Cutter struct {
 	fset      *token.FileSet
@@ -21,12 +26,15 @@ type Cutter struct {
 }
 
 // New creates a [Cutter].
-func New(patterns ...string) (*Cutter, error) {
+func New(opt *CutterOption, patterns ...string) (*Cutter, error) {
+	if opt == nil {
+		opt = &CutterOption{Tests: true}
+	}
 	mode := packages.NeedName | packages.NeedTypes
 	cfg := &packages.Config{
 		Fset:  token.NewFileSet(),
 		Mode:  mode,
-		Tests: true,
+		Tests: opt.Tests,
 	}
 
 	pkgs, err := packages.Load(cfg, patterns...)

--- a/cutter/cutter.go
+++ b/cutter/cutter.go
@@ -24,8 +24,9 @@ type Cutter struct {
 func New(patterns ...string) (*Cutter, error) {
 	mode := packages.NeedName | packages.NeedTypes
 	cfg := &packages.Config{
-		Fset: token.NewFileSet(),
-		Mode: mode,
+		Fset:  token.NewFileSet(),
+		Mode:  mode,
+		Tests: true,
 	}
 
 	pkgs, err := packages.Load(cfg, patterns...)

--- a/cutter/cutter_test.go
+++ b/cutter/cutter_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	c, err := cutter.New("fmt")
+	cutterOpt := &cutter.CutterOption{Tests: true}
+	c, err := cutter.New(cutterOpt, "fmt")
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}

--- a/knife.go
+++ b/knife.go
@@ -27,13 +27,17 @@ type Knife struct {
 	ins  map[*packages.Package]*inspector.Inspector
 }
 
-func New(patterns ...string) (*Knife, error) {
+func New(opt *KnifeOption, patterns ...string) (*Knife, error) {
+	if opt == nil {
+		opt = &KnifeOption{Tests: true}
+	}
+	
 	mode := packages.NeedFiles | packages.NeedSyntax |
 		packages.NeedTypes | packages.NeedDeps | packages.NeedTypesInfo
 	cfg := &packages.Config{
 		Fset:  token.NewFileSet(),
 		Mode:  mode,
-		Tests: true,
+		Tests: opt.Tests,
 	}
 
 	pkgs, err := packages.Load(cfg, patterns...)
@@ -67,14 +71,19 @@ func (k *Knife) Position(v any) token.Position {
 	return token.Position{}
 }
 
-// Option is a option of Execute.
-type Option struct {
+// KnifeOption is an option for New.
+type KnifeOption struct {
+	Tests bool
+}
+
+// ExecuteOption is an option for Execute.
+type ExecuteOption struct {
 	XPath     string
 	ExtraData map[string]any
 }
 
 // Execute outputs the pkg with the format.
-func (k *Knife) Execute(w io.Writer, pkg *packages.Package, tmpl any, opt *Option) error {
+func (k *Knife) Execute(w io.Writer, pkg *packages.Package, tmpl any, opt *ExecuteOption) error {
 
 	var tmplStr string
 	switch tmpl := tmpl.(type) {

--- a/knife.go
+++ b/knife.go
@@ -31,7 +31,7 @@ func New(opt *KnifeOption, patterns ...string) (*Knife, error) {
 	if opt == nil {
 		opt = &KnifeOption{Tests: true}
 	}
-	
+
 	mode := packages.NeedFiles | packages.NeedSyntax |
 		packages.NeedTypes | packages.NeedDeps | packages.NeedTypesInfo
 	cfg := &packages.Config{

--- a/knife.go
+++ b/knife.go
@@ -31,8 +31,9 @@ func New(patterns ...string) (*Knife, error) {
 	mode := packages.NeedFiles | packages.NeedSyntax |
 		packages.NeedTypes | packages.NeedDeps | packages.NeedTypesInfo
 	cfg := &packages.Config{
-		Fset: token.NewFileSet(),
-		Mode: mode,
+		Fset:  token.NewFileSet(),
+		Mode:  mode,
+		Tests: true,
 	}
 
 	pkgs, err := packages.Load(cfg, patterns...)

--- a/mcp/cutter.go
+++ b/mcp/cutter.go
@@ -48,7 +48,8 @@ func cutterHandler(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallT
 	}
 
 	// Create cutter instance
-	c, err := cutter.New(input.Patterns...)
+	cutterOpt := &cutter.CutterOption{Tests: true}
+	c, err := cutter.New(cutterOpt, input.Patterns...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cutter: %w", err)
 	}

--- a/mcp/knife.go
+++ b/mcp/knife.go
@@ -50,13 +50,14 @@ func knifeHandler(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallTo
 	}
 
 	// Create knife instance
-	k, err := knife.New(input.Patterns...)
+	knifeOpt := &knife.KnifeOption{Tests: true}
+	k, err := knife.New(knifeOpt, input.Patterns...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create knife: %w", err)
 	}
 
 	// Set up options
-	opt := &knife.Option{
+	opt := &knife.ExecuteOption{
 		XPath: input.XPath,
 	}
 


### PR DESCRIPTION
Add `-tests` flag to control whether test files are included in analysis.

- `-tests=true` (default) - includes test files  
- `-tests=false` - excludes test files
- Available for both knife and cutter commands