### PR TITLE
Add Makefile and link checking script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: help test build check-links
+
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run tests with race detection
+	go run golang.org/x/tools/cmd/goimports@latest -local $$(go list -m) -w .
+	go test -race ./...
+
+build: ## Build all binaries
+	go build ./cmd/knife
+	go build ./cmd/cutter
+	go build ./cmd/hagane
+	go build ./cmd/objls
+	go build ./cmd/typels
+
+check-links: ## Check for broken links in documentation
+	./script/check-links.sh

--- a/script/check-links.sh
+++ b/script/check-links.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Check for broken links in documentation files
+
+set -e
+
+echo "Checking documentation links..."
+
+# Find all markdown files
+md_files=$(find . -name "*.md" -not -path "./vendor/*")
+
+broken_links=0
+
+for file in $md_files; do
+    echo "Checking $file..."
+    
+    # Extract URLs from markdown files
+    urls=$(grep -oE 'https?://[^)]+' "$file" 2>/dev/null || true)
+    
+    for url in $urls; do
+        # Check HTTP status
+        status=$(curl -I -s -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
+        
+        if [[ "$status" -ge 400 ]] || [[ "$status" == "000" ]]; then
+            echo "❌ BROKEN: $url (HTTP $status) in $file"
+            broken_links=$((broken_links + 1))
+        else
+            echo "✅ OK: $url (HTTP $status)"
+        fi
+    done
+done
+
+if [[ $broken_links -gt 0 ]]; then
+    echo "Found $broken_links broken link(s)"
+    exit 1
+else
+    echo "All links are working!"
+fi


### PR DESCRIPTION
Add development tooling:

- **Makefile**: Common development tasks (test, build, check-links)
- **script/check-links.sh**: Automated link checking for documentation

Available commands:
- `make test` - Run tests with goimports
- `make build` - Build all binaries  
- `make check-links` - Check documentation links
- `make help` - Show available commands